### PR TITLE
Export `MJDEpoch`, representing the Modified Julian Date epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to the
 * In `localTimeParseE` etc, `Format_Spaces` now parses one or more space-like
   characters (as previously documented), rather than one space character (as
   previously implemented).
+* Export `MJDEpoch`, representing the Modified Julian Date (MJD) epoch.
 * Drop deprecated modules `Data.Hourglass.Compat`, `Data.Hourglass.Epoch`,
   `Data.Hourglass.Types` and `System.Hourglass`. Use modules `Time.Compat`,
   `Time.Epoch` and `Time.Types`.

--- a/src/Time/Epoch.hs
+++ b/src/Time/Epoch.hs
@@ -20,6 +20,7 @@ module Time.Epoch
     -- * Commonly-encountered epochs
   , UnixEpoch (..)
   , WindowsEpoch (..)
+  , MJDEpoch (..)
   ) where
 
 import           Control.DeepSeq ( NFData (..) )
@@ -100,6 +101,15 @@ data WindowsEpoch = WindowsEpoch
 instance Epoch WindowsEpoch where
   epochName _ = "windows"
   epochDiffToUnix _ = -11644473600
+
+-- | A type representing the Modified Julian Date (MJD) (a point in time
+-- represented by 1858-11-17 00:00:00 UTC).
+data MJDEpoch = MJDEpoch
+  deriving (Eq, Show)
+
+instance Epoch MJDEpoch where
+  epochName _ = "Modified Julian Date"
+  epochDiffToUnix _ = -3506716800
 
 instance Epoch epoch => Timeable (ElapsedSince epoch) where
   timeGetElapsedP es = ElapsedP (Elapsed e) 0


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in `CHANGELOG.md`.
* [x] Haddock and in-code documentation has been updated, if necessary

Please also describe how you tested your change. Bonus points for added tests!
