### PR TITLE
Refer to non-leap seconds, where applicable

### DIFF
--- a/src/Data/Hourglass.hs
+++ b/src/Data/Hourglass.hs
@@ -8,9 +8,10 @@ Portability : unknown
 Time-related types and functions.
 
 Basic types for representing points in time are t'Elapsed' and t'ElapsedP`. The
-\'P\' is short for \'precise\'. t'Elapsed' represents numbers of seconds elapsed
-since the start of the Unix epoch (1970-01-01 00:00:00 UTC). t'ElapsedP'
-represents numbers of seconds and nanoseconds elapsed.
+\'P\' is short for \'precise\'. t'Elapsed' represents numbers of non-leap
+seconds elapsed since the Unix epoch (that is, the point of time
+represented by 1970-01-01 00:00:00 UTC). t'ElapsedP' represents numbers of
+non-leap seconds and nanoseconds elapsed since that point in time.
 
 Values of other types representing points in time can be converted to and from
 values of the t'Elapsed' and t'ElapsedP' types. For example:
@@ -35,7 +36,7 @@ module Data.Hourglass
   , Month (..)
   , WeekDay (..)
     -- * Points in time
-    -- ** Elapsed time since the start of the Unix epoch
+    -- ** Elapsed time since the Unix epoch
   , Elapsed (..)
   , ElapsedP (..)
     -- ** Date, time, and date and time

--- a/src/Time/Calendar.hs
+++ b/src/Time/Calendar.hs
@@ -95,8 +95,8 @@ daysOfDate :: Date -> Int
 daysOfDate (Date y m d) = daysBeforeYear y + daysUntilMonth y m + d
 
 -- | For the given date in the proleptic Gregorian calendar, and assuming a time
--- of 00:00:00 UTC, yield the number of seconds since the start of the Unix
--- epoch (1970-01-01 00:00:00 UTC). This assumes each day is 24 hours long.
+-- of 00:00:00 UTC, yield the number of non-leap seconds since the Unix epoch
+-- (1970-01-01 00:00:00 UTC).
 dateToUnixEpoch :: Date -> Elapsed
 dateToUnixEpoch date =
   Elapsed $ Seconds (fromIntegral (daysOfDate date - epochDays) * secondsPerDay)
@@ -104,8 +104,9 @@ dateToUnixEpoch date =
   epochDays     = 719_163
   secondsPerDay = 86_400 -- Julian day is 24h
 
--- | For the given period of time since the start of the Unix epoch
--- (1970-01-01 00:00:00 UTC), yield the corresponding date.
+-- | For the given period of time since the Unix epoch
+-- (1970-01-01 00:00:00 UTC), yield the corresponding date in the proleptic
+-- Gregorian calendar.
 dateFromUnixEpoch :: Elapsed -> Date
 dateFromUnixEpoch e = dtDate $ dateTimeFromUnixEpoch e
 
@@ -115,8 +116,8 @@ todToSeconds :: TimeOfDay -> Seconds
 todToSeconds (TimeOfDay h m s _) = toSeconds h + toSeconds m + s
 
 -- | For the given date (in the proleptic Gregorian calendar) and time (in UTC),
--- yield the number of seconds that have elapsed since the start of the Unix
--- epoch.
+-- yield the number of non-leap seconds that have elapsed since the Unix epoch
+-- (1970-01-01 00:00:00 UTC).
 dateTimeToUnixEpoch :: DateTime -> Elapsed
 dateTimeToUnixEpoch (DateTime d t) =
   dateToUnixEpoch d + Elapsed (todToSeconds t)

--- a/src/Time/Compat.hs
+++ b/src/Time/Compat.hs
@@ -41,27 +41,25 @@ module Time.Compat
 import           Time.Time ( timeConvert )
 import           Time.Types ( Date, Elapsed (..), TimeOfDay (..) )
 
--- | Given an integer which represents the number of days since the start of the
--- Unix epoch (1970-01-01 00:00:00 UTC), yield the corresponding date in the
+-- | Given an integer which represents the number of days since the Unix epoch
+-- (1970-01-01 00:00:00 UTC), yield the corresponding date in the
 -- proleptic Gregorian calendar.
 dateFromUnixEpoch ::
      Integer
-     -- ^ Number of days since the start of the Unix epoch
-     -- (1970-01-01 00:00:00 UTC).
+     -- ^ Number of days since the Unix epoch (1970-01-01 00:00:00 UTC).
   -> Date
 dateFromUnixEpoch day = do
   let sec = Elapsed $ fromIntegral $ day * 86_400
   timeConvert sec
 
--- | The number of days between the start of the Modified Julian Date (MJD)
--- epoch (1858-11-17 00:00:00 UTC) and the start of the Unix epoch
--- (1970-01-01 00:00:00 UTC).
+-- | The number of days between the Modified Julian Date (MJD) epoch
+-- (1858-11-17 00:00:00 UTC) and the Unix epoch (1970-01-01 00:00:00 UTC).
 daysMJDtoUnix :: Integer
 daysMJDtoUnix = 40_587
 
--- | Given an integer which represents the number of days since the start of the
--- Modified Julian Date (MJD) epoch (1858-11-17 00:00:00 UTC), yields the
--- corresponding date in the proleptic Gregorian calendar.
+-- | Given an integer which represents the number of days since the Modified
+-- Julian Date (MJD) epoch (1858-11-17 00:00:00 UTC), yields the corresponding
+-- date in the proleptic Gregorian calendar.
 --
 -- This function allows a user to convert a t'Data.Time.Calendar.Day'
 -- into t'Date'.
@@ -78,8 +76,8 @@ dateFromMJDEpoch ::
 dateFromMJDEpoch dtai =
   dateFromUnixEpoch (dtai - daysMJDtoUnix)
 
--- | Given a real number representing the number of seconds since the start of
--- the day, yield a t'TimeOfDay' value.
+-- | Given a real number representing the number of non-leap seconds since the
+-- start of the day, yield a t'TimeOfDay' value (assuming no leap seconds).
 --
 -- Example with t'Data.Time.Clock.DiffTime' type from package @time@:
 --
@@ -99,7 +97,7 @@ dateFromMJDEpoch dtai =
 diffTimeToTimeOfDay ::
     Real t
   => t
-     -- ^ Number of seconds of the time of the day.
+     -- ^ Number of non-leap seconds of the time of the day.
   -> TimeOfDay
 diffTimeToTimeOfDay dt = do
   TimeOfDay

--- a/src/Time/Diff.hs
+++ b/src/Time/Diff.hs
@@ -31,7 +31,8 @@ import           Time.Types
                    )
 
 -- | Type representing periods of time in years, months and days.
--- See t'Duration' for periods of time hours, minutes, seconds and nanoseconds.
+-- See t'Duration' for periods of time in hours, minutes, seconds (non-leap or
+-- all) and nanoseconds.
 data Period = Period
   { periodYears  :: !Int
   , periodMonths :: !Int
@@ -49,13 +50,18 @@ instance Semigroup Period where
 instance Monoid Period where
   mempty = Period 0 0 0
 
--- | Type represeting periods of time in hours, minutes, seconds and
--- nanoseconds. See t'Period' for periods of time in years, months and days.
+-- | Type represeting periods of time in hours, minutes, seconds (non-leap or
+-- all) and nanoseconds. See t'Period' for periods of time in years, months and
+-- days.
 data Duration = Duration
-  { durationHours   :: !Hours       -- ^ number of hours
-  , durationMinutes :: !Minutes     -- ^ number of minutes
-  , durationSeconds :: !Seconds     -- ^ number of seconds
-  , durationNs      :: !NanoSeconds -- ^ number of nanoseconds
+  { durationHours   :: !Hours
+    -- ^ Number of hours.
+  , durationMinutes :: !Minutes
+    -- ^ Number of minutes.
+  , durationSeconds :: !Seconds
+    -- ^ Number of seconds (non-leap or all).
+  , durationNs      :: !NanoSeconds
+    -- ^ Number of nanoseconds.
   }
   deriving (Data, Eq, Ord, Read, Show)
 
@@ -113,11 +119,11 @@ dateAddPeriod (Date yOrig mOrig dOrig) (Period yDiff mDiff dDiff) =
    where
     dMonth = daysInMonth y (toEnum m)
 
--- | Add the given number of seconds to the given t'Elapsed' value.
+-- | Add the given number of non-leap seconds to the given t'Elapsed' value.
 elapsedTimeAddSeconds :: Elapsed -> Seconds -> Elapsed
 elapsedTimeAddSeconds (Elapsed s1) s2 = Elapsed (s1 + s2)
 
--- | Add the given number of seconds to the given t'ElapsedP' value.
+-- | Add the given number of non-leap seconds to the given t'ElapsedP' value.
 elapsedTimeAddSecondsP :: ElapsedP -> Seconds -> ElapsedP
 elapsedTimeAddSecondsP (ElapsedP (Elapsed s1) ns1) s2 =
   ElapsedP (Elapsed (s1 + s2)) ns1

--- a/src/Time/Epoch.hs
+++ b/src/Time/Epoch.hs
@@ -9,11 +9,11 @@ Copyright   : (c) 2014 Vincent Hanquez <vincent@snarc.org>
 Stability   : experimental
 Portability : unknown
 
-Types and functions related to epochs.
+Types, type classes and functions related to epochs.
 -}
 
 module Time.Epoch
-  ( -- * Elapsed time from the start of epochs
+  ( -- * Elapsed time from epochs
     ElapsedSince (..)
   , ElapsedSinceP (..)
     -- * Epoch
@@ -33,13 +33,13 @@ import           Time.Types
                    , Seconds (..)
                    )
 
--- | A type representing the number of seconds that have elapsed since the start
--- of a specified epoch.
+-- | A type representing the number of non-leap seconds that have elapsed since
+-- the specified epoch.
 newtype ElapsedSince epoch = ElapsedSince Seconds
   deriving (Data, Eq, NFData, Num, Ord,  Read, Show)
 
--- | A type representing the number of seconds and nanoseconds that have elapsed
--- since the start of a specified epoch. The \'P\' is short for \'precise\'.
+-- | A type representing the number of non-leap seconds and nanoseconds that
+-- have elapsed since the specified epoch. The \'P\' is short for \'precise\'.
 data ElapsedSinceP epoch = ElapsedSinceP
   {-# UNPACK #-} !(ElapsedSince epoch)
   {-# UNPACK #-} !NanoSeconds
@@ -73,19 +73,19 @@ instance Real (ElapsedSinceP e) where
   toRational (ElapsedSinceP (ElapsedSince (Seconds s)) (NanoSeconds ns)) =
     fromIntegral s + (fromIntegral ns % 1_000_000_000)
 
--- | A type class promising epoch-related functionality.
---
+-- | A type class promising epoch-related functionality. (Epochs, in this
+-- context, are fixed points in time.)
 class Epoch epoch where
   -- | The name of the epoch.
   epochName :: epoch -> String
 
-  -- | The start of the epoch relative to the start of the Unix epoch
-  -- (1970-01-01 00:00:00 UTC), in seconds. A negative number means the epoch
-  -- starts before the starts of the Unix epoch.
+  -- | The epoch relative to the Unix epoch (1970-01-01 00:00:00 UTC), in
+  -- non-leap seconds. A negative number means the epoch is before the Unix
+  -- epoch.
   epochDiffToUnix :: epoch -> Seconds
 
--- | A type representing the Unix epoch, which started on
--- 1970-01-01 00:00:00 UTC.
+-- | A type representing the Unix epoch (the point in time represented by
+-- 1970-01-01 00:00:00 UTC).
 data UnixEpoch = UnixEpoch
   deriving (Eq, Show)
 
@@ -95,7 +95,7 @@ instance Epoch UnixEpoch where
 
 -- | A type representing the
 -- [Windows epoch](https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times),
--- which started on 1601-01-01 00:00:00 UTC.
+-- (the point in time represented by 1601-01-01 00:00:00 UTC).
 data WindowsEpoch = WindowsEpoch
   deriving (Eq, Show)
 
@@ -103,7 +103,7 @@ instance Epoch WindowsEpoch where
   epochName _ = "windows"
   epochDiffToUnix _ = -11_644_473_600
 
--- | A type representing the Modified Julian Date (MJD) (a point in time
+-- | A type representing the Modified Julian Date (MJD) epoch (the point in time
 -- represented by 1858-11-17 00:00:00 UTC).
 data MJDEpoch = MJDEpoch
   deriving (Eq, Show)

--- a/src/Time/Format.hs
+++ b/src/Time/Format.hs
@@ -77,7 +77,7 @@ data TimeFormatElem =
   | Format_Second
     -- ^ Seconds padded to 2 characters (@00@ to @59@, @60@ for leap seconds).
   | Format_UnixSecond
-    -- ^ Number of seconds since the start of the Unix epoch
+    -- ^ Number of non-leap seconds since the Unix epoch
     -- (1970-01-01 00:00:00 UTC).
   | Format_MilliSecond
     -- ^ The millisecond component only, padded to 3 characters (@000@ to
@@ -163,7 +163,7 @@ newtype TimeFormatString = TimeFormatString [TimeFormatElem]
 -- [@MI@]:    'Format_Minute'. Minutes padded to 2 characters (@00@ to @59@).
 -- [@S@]:     'Format_Second'. Seconds padded to 2 characters (@00@ to @59@,
 --            @60@ for leap seconds).
--- [@EPOCH@]: 'Format_UnixSecond'. Number of seconds since the start of the Unix
+-- [@EPOCH@]: 'Format_UnixSecond'. Number of non-leap seconds since the Unix
 --            epoch (1970-01-01 00:00:00 UTC).
 -- [@ms@]:    'Format_MilliSecond'. The millisecond component only, padded to 3
 --            characters (@000@ to @999@). See @us@/@μ@ and @ns@ for other named

--- a/src/Time/System.hs
+++ b/src/Time/System.hs
@@ -28,13 +28,12 @@ import           Time.LocalTime
 import           Time.Time ( timeGetDateTimeOfDay )
 import           Time.Types ( DateTime, Elapsed, ElapsedP, TimezoneOffset )
 
--- | Get the current number of seconds elapsed since the start of the Unix
--- epoch.
+-- | Get the current number of non-leap seconds elapsed since the Unix epoch.
 timeCurrent :: IO Elapsed
 timeCurrent = systemGetElapsed
 
--- | Get the current number of seconds and nanoseconds since the start of the
--- Unix epoch (1970-01-01 00:00:00 UTC).
+-- | Get the current number of non-leap seconds and nanoseconds since the Unix
+-- epoch (1970-01-01 00:00:00 UTC).
 timeCurrentP :: IO ElapsedP
 timeCurrentP = systemGetElapsedP
 

--- a/src/Time/Time.hs
+++ b/src/Time/Time.hs
@@ -52,12 +52,12 @@ import           Time.Types
 --   question (should yield @0@ when the type is less precise than seconds).
 --
 class Timeable t where
-  -- | Convert the given value to the number of elapsed seconds and nanoseconds
-  -- since the start of the Unix epoch (1970-01-01 00:00:00 UTC).
+  -- | Convert the given value to the number of non-leap seconds and
+  -- nanoseconds elapsed since the Unix epoch (1970-01-01 00:00:00 UTC).
   timeGetElapsedP :: t -> ElapsedP
 
-  -- | Convert the given value to the number of elapsed seconds since the start
-  -- of the Unix epoch (1970-01-01 00:00:00 UTC).
+  -- | Convert the given value to the number of non-leap seconds elapsed since
+  -- the Unix epoch (1970-01-01 00:00:00 UTC).
   --
   -- Defaults to 'timeGetElapsedP'.
   timeGetElapsed :: t -> Elapsed
@@ -80,12 +80,12 @@ class Timeable t where
 -- | A type class promising functionality for converting t'ElapsedP' values
 -- and t'Elapsed' values to values of the type in question.
 class Timeable t => Time t where
-  -- | Convert from a number of elapsed seconds and nanoseconds since the start
-  -- of the Unix epoch (1970-01-01 00:00:00 UTC).
+  -- | Convert from a number of non-leap seconds and nanoseconds elapsed since
+  -- the Unix epoch (1970-01-01 00:00:00 UTC).
   timeFromElapsedP :: ElapsedP -> t
 
-  -- | Convert from a number of elapsed seconds since the start of the Unix
-  -- epoch (1970-01-01 00:00:00 UTC).
+  -- | Convert from a number of non-leap seconds elapsed since the Unix epoch
+  -- (1970-01-01 00:00:00 UTC).
   --
   -- Defaults to 'timeFromElapsedP'.
   timeFromElapsed :: Elapsed -> t

--- a/src/Time/Types.hs
+++ b/src/Time/Types.hs
@@ -22,7 +22,7 @@ module Time.Types
   , Month (..)
   , WeekDay (..)
     -- * Points in time
-    -- ** Elapsed time since the start of the Unix epoch
+    -- ** Elapsed time since the Unix epoch
   , Elapsed (..)
   , ElapsedP (..)
     -- ** Date, time, and date and time
@@ -50,11 +50,13 @@ import           Time.Utils ( pad2 )
 -- * converting a t'Seconds' value to a pair of a value of the type in question
 --   and a remaining number of seconds.
 class TimeInterval i where
-  -- | For the given value, yield a corresponding number of seconds.
+  -- | For the given value, yield a corresponding number of seconds (non-leap or
+  -- all).
   toSeconds   :: i -> Seconds
 
-  -- | For the given number of seconds, yield a pair of the corresponding value
-  -- of the type in queston and a remaining number of seconds.
+  -- | For the given number of seconds (non-leap or all), yield a pair of the
+  -- corresponding value of the type in queston and a remaining number of
+  -- seconds.
   fromSeconds :: Seconds -> (i, Seconds)
 
 -- | Type representing numbers of nanoseconds.
@@ -68,7 +70,7 @@ instance TimeInterval NanoSeconds where
   toSeconds (NanoSeconds ns) = Seconds (ns `div` 1000000000)
   fromSeconds (Seconds s) = (NanoSeconds (s * 1000000000), 0)
 
--- | Type representing numbers of seconds.
+-- | Type representing numbers of seconds (non-leap or all).
 newtype Seconds = Seconds Int64
   deriving (Data, Eq, Enum, Integral, NFData, Num, Ord, Read, Real)
 
@@ -105,16 +107,16 @@ instance TimeInterval Hours where
    where
     (h, s') = s `divMod` 3600
 
--- | Type representing numbers of seconds elapsed since the start of the Unix
--- epoch (1970-01-01 00:00:00 UTC).
+-- | Type representing numbers of non-leap seconds elapsed since the Unix epoch
+-- (1970-01-01 00:00:00 UTC).
 newtype Elapsed = Elapsed Seconds
   deriving (Data, Eq, NFData, Num, Ord, Read)
 
 instance Show Elapsed where
   show (Elapsed s) = show s
 
--- | Type representing numbers of seconds and nanoseconds elapsed since the
--- start of the Unix epoch (1970-01-01 00:00:00 UTC).
+-- | Type representing numbers of non-leap seconds and nanoseconds elapsed since
+-- the Unix epoch (1970-01-01 00:00:00 UTC).
 data ElapsedP = ElapsedP {-# UNPACK #-} !Elapsed {-# UNPACK #-} !NanoSeconds
   deriving (Data, Eq, Ord, Read)
 
@@ -250,9 +252,9 @@ data TimeOfDay = TimeOfDay
   , todMin  :: {-# UNPACK #-} !Minutes
     -- ^ Minutes, between 0 and 59.
   , todSec  :: {-# UNPACK #-} !Seconds
-    -- ^ Seconds, between 0 and 59. 60 when having leap second.
+    -- ^ Seconds, between 0 and 59. A leap second is represented by 60.
   , todNSec :: {-# UNPACK #-} !NanoSeconds
-    -- ^ Nanoseconds, between 0 and 999999999.
+    -- ^ Nanoseconds, between 0 and 999,999,999.
   }
   deriving (Data, Eq, Ord, Read, Show)
 


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in `CHANGELOG.md`.
* [x] Haddock and in-code documentation has been updated, if necessary

Please also describe how you tested your change. Bonus points for added tests!
