### PR TITLE
Fix #9 Add `fromRationalElapsedP` and related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to the
 ## UNRELEASED
 
 * Drop support for GHC < 8.6.
+* Add `Real` instance for `ElapsedSinceP`.
+* Export `fromRationalSecondsP`, `mkElapsedP`, and `fromRationalElapsedP`, to
+  facilitate creation of `ElapsedP` values from precise amounts of seconds or
+  numbers of seconds and nanoseconds.
+* Test added to test suite for `toRational :: ElapsedSinceP -> Rational` and
+  `fromRationalElapsedP`.
 * Change the types of fields of `TimeFormatFct`: the parser and printer are in
   terms of `DateTime` and `TimezoneOffset` (rather than just `DateTime`).
 * In `localTimePrint` etc, implement `Format_TimezoneName` and `Format_Fct`.
@@ -24,7 +30,6 @@ and this project adheres to the
   `Time.Epoch` and `Time.Types`.
 * Drop deprecated function `dateFromPOSIXEpoch`. Use `dataFromUnixEpoch`.
 * Drop deprecated function `dateFromTAIEpoch`. Use `dateFromMJDEpoch`.
-* Add `Real` instance for `ElapsedSinceP`.
 * Fix Haddock documentaton for `Format_Hours`, `Format_Minutes` and
   `Format_Seconds`; they all pad to 2 characters.
 * Fix Haddock documentaton for `Format_Millisecond`, `Format_MicroSecond` and

--- a/src/Data/Hourglass.hs
+++ b/src/Data/Hourglass.hs
@@ -36,9 +36,13 @@ module Data.Hourglass
   , Month (..)
   , WeekDay (..)
     -- * Points in time
+    -- ** Precise amounts of seconds
+  , fromRationalSecondsP
     -- ** Elapsed time since the Unix epoch
   , Elapsed (..)
   , ElapsedP (..)
+  , mkElapsedP
+  , fromRationalElapsedP
     -- ** Date, time, and date and time
   , Date (..)
   , TimeOfDay (..)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -17,7 +17,7 @@ import           Data.Hourglass
                    , ISO8601_DateAndTime (..), LocalTime, Minutes (..)
                    , Month (..), NanoSeconds (..), Period (..), Seconds (..)
                    , Time, TimeFormat (..), TimeFormatElem (..), TimeOfDay (..)
-                   , TimezoneOffset (..), WeekDay, dateAddPeriod, daysInMonth
+                   , TimezoneOffset (..), WeekDay, dateAddPeriod, daysInMonth, fromRationalElapsedP
                    , getWeekDay, localTime, localTimeFromGlobal
                    , localTimeGetTimezone, localTimeParseE, localTimeSetTimezone
                    , localTimeToGlobal, timeConvert, timeGetDateTimeOfDay
@@ -82,6 +82,9 @@ instance Arbitrary NanoSeconds where
 
 instance Arbitrary Elapsed where
   arbitrary = Elapsed <$> arbitrary
+
+instance Arbitrary ElapsedP where
+  arbitrary = ElapsedP <$> arbitrary <*> arbitrary
 
 instance Arbitrary TimezoneOffset where
   arbitrary = TimezoneOffset <$> choose (-(11*60), 11*60)
@@ -180,6 +183,8 @@ tests knowns = testGroup "hourglass"
           let e2 = timeConvert e :: ElapsedSince WindowsEpoch
           in       timePrint ISO8601_DateAndTime e
               `eq` timePrint ISO8601_DateAndTime e2
+      , testProperty "precise seconds" $ \(ep :: ElapsedP) ->
+          fromRationalElapsedP (toRational ep) `eq` ep
       ]
   , testGroup "localtime"
       [ testProperty "eq" $ \(l :: LocalTime Elapsed) ->


### PR DESCRIPTION
Also adds `mkElapsedP` and `fromRationalSecondsP`.

Also adds a test for `toRational :: ElapsedP -> Rational` and `fromRationalElapsedP`.

* [x] Any changes that could be relevant to users have been recorded in `CHANGELOG.md`.
* [x] Haddock and in-code documentation has been updated, if necessary

Please also describe how you tested your change. Bonus points for added tests!
